### PR TITLE
[Easy] make npm run-coverage work

### DIFF
--- a/contracts/Imports.sol
+++ b/contracts/Imports.sol
@@ -3,3 +3,5 @@ pragma solidity ^0.4.24;
 // We import the contract so truffle compiles it, and we have the ABI 
 // available when working from truffle console.
 import "@gnosis.pm/mock-contract/contracts/MockContract.sol";
+
+contract Import {} // Needed for coverage to not fail


### PR DESCRIPTION
Looks like every .sol file needs at least one contract.