### PR TITLE
Removing print in commit hook, moving to folder

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -4,8 +4,6 @@ STAGED_JS_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep ".jsx\{
 STAGED_SOL_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep ".sol")
 ESLINT="$(git rev-parse --show-toplevel)/node_modules/.bin/eslint"
 
-printf STAGED_SOL_FILES
-
 if [[ ("$STAGED_JS_FILES" = "") && ("$STAGED_SOL_FILES" = "") ]]; then
   exit 0
 fi


### PR DESCRIPTION
I think it's cleaner to have a separate folder for commit hooks. Also the script is currently printing staged solfiles, which I believe is a relict from developing it.