### PR TITLE
Test validate.checkSigs

### DIFF
--- a/contracts/Validate.sol
+++ b/contracts/Validate.sol
@@ -26,7 +26,7 @@ library Validate {
 
         bool check1 = txHashSig1 == ECRecovery.recover(ECRecovery.toEthSignedMessageHash(confirmationHash), confSig1);
 
-        if (inputCount > 0) {
+        if (inputCount > 0 && check1) {  // && allows us to short circuit if check1 is already false.
             bytes memory sig2 = BytesLib.slice(sigs, 65, 65);
             bytes memory confSig2 = BytesLib.slice(sigs, 195, 65);
 

--- a/contracts/Validate.sol
+++ b/contracts/Validate.sol
@@ -16,7 +16,6 @@ library Validate {
     {
         require(sigs.length % 65 == 0 && sigs.length <= 260, "Signatures failed length verification");
         bytes memory sig1 = BytesLib.slice(sigs, 0, 65);
-        bytes memory sig2 = BytesLib.slice(sigs, 65, 65);
         bytes memory confSig1 = BytesLib.slice(sigs, 130, 65);
         bytes32 confirmationHash = keccak256(abi.encodePacked(txHash, rootHash));
 
@@ -28,8 +27,10 @@ library Validate {
         bool check1 = txHashSig1 == ECRecovery.recover(ECRecovery.toEthSignedMessageHash(confirmationHash), confSig1);
 
         if (inputCount > 0) {
+            bytes memory sig2 = BytesLib.slice(sigs, 65, 65);
             bytes memory confSig2 = BytesLib.slice(sigs, 195, 65);
-            address txHashSig2 = ECRecovery.recover(txHash, sig2);
+
+            address txHashSig2 = ECRecovery.recover(ECRecovery.toEthSignedMessageHash(txHash), sig2);
             require(txHashSig2 != 0, "Error 2: while evaluating ecrecover on transaction-sig2");
             check2 = txHashSig2 == ECRecovery.recover(ECRecovery.toEthSignedMessageHash(confirmationHash), confSig2);
         }

--- a/test/utilities.js
+++ b/test/utilities.js
@@ -116,28 +116,6 @@ const rlpEncodeTransaction = function(exitor, token, amount, inputCount, oindex)
   return RLP.encode(list)
 }
 
-function keccak256(...args) {
-  args = args.map(arg => {
-    if (typeof arg === "string") {
-      if (arg.substring(0, 2) === "0x") {
-        return arg.slice(2)
-      } else {
-        return web3.toHex(arg).slice(2)
-      }
-    }
-
-    if (typeof arg === "number") {
-      return leftPad((arg).toString(16), 64, 0)
-    } else {
-      return ""
-    }
-  })
-
-  args = args.join("")
-
-  return web3.sha3(args, { encoding: "hex" })
-}
-
 const fastForward = async function(seconds) {
   const oldTime = (await web3.eth.getBlock(await web3.eth.blockNumber)).timestamp
   await web3.currentProvider.send({jsonrpc: "2.0", method: "evm_increaseTime", params: [seconds], id: 0})
@@ -151,7 +129,6 @@ const fastForward = async function(seconds) {
 module.exports = {
   assertRejects,
   catchError,
-  keccak256,
   fromHex,
   toHex,
   waitForNBlocks,

--- a/test/utilities.js
+++ b/test/utilities.js
@@ -50,6 +50,28 @@ const BlockType = {
   AuctionOutput: 5,
 }
 
+function keccak256(...args) {
+  args = args.map(arg => {
+    if (typeof arg === "string") {
+      if (arg.substring(0, 2) === "0x") {
+        return arg.slice(2)
+      } else {
+        return web3.toHex(arg).slice(2)
+      }
+    }
+
+    if (typeof arg === "number") {
+      return leftPad((arg).toString(16), 64, 0)
+    } else {
+      return ""
+    }
+  })
+
+  args = args.join("")
+
+  return web3.sha3(args, { encoding: "hex" })
+}
+
 // Fast forward 1 week
 // let fastForward = async function() {
 //   let oldTime = (await web3.eth.getBlock(await web3.eth.blockNumber)).timestamp;
@@ -64,6 +86,7 @@ const BlockType = {
 module.exports = {
   assertRejects,
   catchError,
+  keccak256,
   toHex,
   waitForNBlocks,
   encodeUtxoPosition,

--- a/test/validate.js
+++ b/test/validate.js
@@ -1,10 +1,11 @@
 const ValidateWrapper = artifacts.require("ValidateWrapper")
 
 const {
-  assertRejects
+  assertRejects,
+  toHex
 } = require("./utilities.js")
 
-contract("Validate", () => {
+contract("Validate", (accounts) => {
   const zeroHash32 = "0x" + "00".repeat(32)
   const zeroSig195 = "0x" + "00".repeat(195)
 
@@ -26,6 +27,32 @@ contract("Validate", () => {
       assert.equal(res, false)
     })
 
-    // TODO - Get Validator to pass
+    // it("Test checkSigs naive", async () => {
+    //   const validator = await ValidateWrapper.new()
+    //   const signer = accounts[5]
+    //   const invalidSigner = accounts[6]
+
+    //   const txHash = web3.sha3("tx bytes to be hashed")
+    //   const sigs = await web3.eth.sign(signer, txHash)
+
+    //   // sigs += Buffer.alloc(65).toString("hex")
+
+    //   const confirmationHash = web3.sha3("merkle leaf hash concat with root hash")
+
+    //   const confirmSignatures = await web3.eth.sign(signer, confirmationHash)
+
+    //   const invalidConfirmSignatures = await web3.eth.sign(invalidSigner, confirmationHash)
+    //   // assert valid confirmSignatures will pass checkSigs
+    //   assert.isTrue(
+    //     await validator.checkSigs.call(txHash, toHex(confirmationHash), 0, toHex(sigs + confirmSignatures.slice(2))), 
+    //     "checkSigs should pass."
+    //   )
+
+    //   // assert invalid confirmSignatures will not pass checkSigs
+    //   assert.isFalse(
+    //     await validator.checkSigs.call(txHash, toHex(confirmationHash), 0, toHex(sigs), toHex(invalidConfirmSignatures)), 
+    //     "checkSigs should not pass given invalid confirmSignatures."
+    //   )
+    // })
   })
 })

--- a/test/validate.js
+++ b/test/validate.js
@@ -2,14 +2,21 @@ const ValidateWrapper = artifacts.require("ValidateWrapper")
 
 const {
   assertRejects,
-  keccak256
+  keccak256,
+  toHex
 } = require("./utilities.js")
 
-// const { sha3 } = require("ethereumjs-util")
+const { sha3 } = require("ethereumjs-util")
 
 contract("Validate", (accounts) => {
   const zeroHash32 = "0x" + "00".repeat(32)
   const zeroSig195 = "0x" + "00".repeat(195)
+
+  const txHash = toHex(sha3("tx bytes to be hashed"))
+  const rootHash = toHex(sha3("merkle root hash"))
+  const confirmHash = keccak256(txHash, rootHash)
+
+  const [signer1, signer2, invalidSigner] = accounts
 
   describe("checkSigs", () => {
 
@@ -28,29 +35,28 @@ contract("Validate", (accounts) => {
       await assertRejects(validator.checkSigs(zeroHash32, zeroHash32, 0, zeroSig195))
     })
 
-    it("Basic Pass & Fail - Single Input", async () => {
+    it("accepts valid signature with one input", async () => {
       const validator = await ValidateWrapper.new()
 
-      const signer = accounts[1]
-      const invalidSigner = accounts[2]
-
-      const txHash = web3.sha3("tx bytes to be hashed")
-      let sigs = await web3.eth.sign(signer, txHash)
-
       // padding with zeros because only one txn input
-      sigs += Buffer.alloc(65).toString("hex")
-      const rootHash = web3.sha3("merkle root hash")
+      const sigs = (await web3.eth.sign(signer1, txHash)) + Buffer.alloc(65).toString("hex")
 
-      const confirmHash = keccak256(txHash, rootHash)
-
-      const confirmSignature = await web3.eth.sign(signer, confirmHash)
-      const invalidConfirmSignature = await web3.eth.sign(invalidSigner, confirmHash)
+      const confirmSignature = await web3.eth.sign(signer1, confirmHash)
 
       // assert valid confirmSignatures will pass checkSigs
       assert.isTrue(
         await validator.checkSigs.call(txHash, rootHash, 0, sigs + confirmSignature.slice(2)),
-        "checkSigs doesn't return true when it should"
+        "checkSigs should return true."
       )
+    })
+
+    it("fail invalid signature with one input", async () => {
+      const validator = await ValidateWrapper.new()
+
+      // padding with zeros because only one txn input
+      const sigs = (await web3.eth.sign(signer1, txHash)) + Buffer.alloc(65).toString("hex")
+
+      const invalidConfirmSignature = await web3.eth.sign(invalidSigner, confirmHash)
 
       // assert invalid confirmSignatures will not pass checkSigs
       assert.isFalse(
@@ -59,58 +65,114 @@ contract("Validate", (accounts) => {
       )
     })
 
-    it("Basic Pass & Fail - Two Inputs", async () => {
+    it("Pass Two Inputs", async () => {
       const validator = await ValidateWrapper.new()
 
-      const signer1 = accounts[1]
-      const signer2 = accounts[2]
-      const invalidSigner = accounts[3]
-
-      const txHash = web3.sha3("tx bytes to be hashed")
       // Same transaction signed by both 1 and 2
       const signature1 = await web3.eth.sign(signer1, txHash)
       const signature2 = await web3.eth.sign(signer2, txHash)
 
       const initialSigs = signature1 + signature2.slice(2)
 
-      const rootHash = web3.sha3("merkle root hash")
-      const confirmHash = keccak256(txHash, rootHash)
-
       const confirmSignature1 = (await web3.eth.sign(signer1, confirmHash)).slice(2)
       const confirmSignature2 = (await web3.eth.sign(signer2, confirmHash)).slice(2)
 
-      const legitConfirmSigs = confirmSignature1 + confirmSignature2
-      const reverseConfirmSigs = confirmSignature2 + confirmSignature1
-
-      const invalidConfirmSignature = (await web3.eth.sign(invalidSigner, confirmHash)).slice(2)
-
       // assert valid confirmSignatures will pass checkSigs
       assert.isTrue(
-        await validator.checkSigs.call(txHash, rootHash, 1, initialSigs + legitConfirmSigs),
+        await validator.checkSigs.call(txHash, rootHash, 1, initialSigs + confirmSignature1 + confirmSignature2),
         "checkSigs doesn't return true when it should"
       )
+
+    })
+
+    it("Fail Two Inputs - reversed confirmation signatures", async () => {
+      const validator = await ValidateWrapper.new()
+
+      // Same transaction signed by both 1 and 2
+      const signature1 = await web3.eth.sign(signer1, txHash)
+      const signature2 = await web3.eth.sign(signer2, txHash)
+
+      const initialSigs = signature1 + signature2.slice(2)
+      const confirmSignature1 = (await web3.eth.sign(signer1, confirmHash)).slice(2)
+      const confirmSignature2 = (await web3.eth.sign(signer2, confirmHash)).slice(2)
+
+      const reverseConfirmSigs = confirmSignature2 + confirmSignature1
 
       // assert invalid confirmSignatures will not pass checkSigs
       assert.isFalse(
         await validator.checkSigs.call(txHash, rootHash, 1, initialSigs + reverseConfirmSigs),
         "reversed confirmation signatures shouldn't pass"
       )
+    })
 
+    it("Fail Two Inputs - invalid confirmation signature on first input", async () => {
+      const validator = await ValidateWrapper.new()
+
+      // Same transaction signed by both 1 and 2
+      const signature1 = await web3.eth.sign(signer1, txHash)
+      const signature2 = await web3.eth.sign(signer2, txHash)
+
+      const initialSigs = signature1 + signature2.slice(2)
+      const confirmSignature2 = (await web3.eth.sign(signer2, confirmHash)).slice(2)
+
+      const invalidConfirmSignature = (await web3.eth.sign(invalidSigner, confirmHash)).slice(2)
+
+      // assert invalid confirmSignatures will not pass checkSigs
       assert.isFalse(
         await validator.checkSigs.call(txHash, rootHash, 1, initialSigs + invalidConfirmSignature + confirmSignature2),
         "invalid confirm signature in first of two positions shouldn't pass"
       )
+    })
 
+    it("Fail Two Inputs - invalid confirmation signature on second input", async () => {
+      const validator = await ValidateWrapper.new()
+
+      // Same transaction signed by both 1 and 2
+      const signature1 = await web3.eth.sign(signer1, txHash)
+      const signature2 = await web3.eth.sign(signer2, txHash)
+
+      const initialSigs = signature1 + signature2.slice(2)
+
+      const confirmSignature1 = (await web3.eth.sign(signer1, confirmHash)).slice(2)
+      const invalidConfirmSignature = (await web3.eth.sign(invalidSigner, confirmHash)).slice(2)
+
+      // assert invalid confirmSignatures will not pass checkSigs
       assert.isFalse(
         await validator.checkSigs.call(txHash, rootHash, 1, initialSigs + confirmSignature1 + invalidConfirmSignature),
         "invalid confirm signature in second of two positions shouldn't pass"
       )
+    })
 
+
+    it("Fail Two Inputs - reversed initial signatures", async () => {
+      const validator = await ValidateWrapper.new()
+
+      // Same transaction signed by both 1 and 2
+      const signature1 = await web3.eth.sign(signer1, txHash)
+      const signature2 = await web3.eth.sign(signer2, txHash)
+
+      const confirmSignature1 = (await web3.eth.sign(signer1, confirmHash)).slice(2)
+      const confirmSignature2 = (await web3.eth.sign(signer2, confirmHash)).slice(2)
+
+      const legitConfirmSigs = confirmSignature1 + confirmSignature2
+
+      // assert invalid confirmSignatures will not pass checkSigs
       assert.isFalse(
         await validator.checkSigs.call(txHash, rootHash, 1, signature2 + signature1.slice(2) + legitConfirmSigs),
         "wrong order transaction signatures shouldn't pass"
       )
     })
+
+
+
+
+
+
+
+
+
+
+
   })
 
 })

--- a/test/validate.js
+++ b/test/validate.js
@@ -28,7 +28,7 @@ contract("Validate", (accounts) => {
       await assertRejects(validator.checkSigs(zeroHash32, zeroHash32, 0, zeroSig195))
     })
 
-    it("Basic Pass & Fail: Single Input", async () => {
+    it("Basic Pass & Fail - Single Input", async () => {
       const validator = await ValidateWrapper.new()
 
       const signer = accounts[1]
@@ -49,14 +49,51 @@ contract("Validate", (accounts) => {
       // assert valid confirmSignatures will pass checkSigs
       assert.isTrue(
         await validator.checkSigs.call(txHash, rootHash, 0, sigs + confirmSignature.slice(2)),
-        "checkSigs should pass."
+        "checkSigs doesn't return true when it should"
       )
 
-      // // assert invalid confirmSignatures will not pass checkSigs
+      // assert invalid confirmSignatures will not pass checkSigs
       assert.isFalse(
-        await validator.checkSigs.call(txHash, rootHash, 0, sigs + invalidConfirmSignature.slice(2)), 
-        "checkSigs should not pass given invalid confirmSignatures."
+        await validator.checkSigs.call(txHash, rootHash, 0, sigs + invalidConfirmSignature.slice(2)),
+        "checkSigs doesn't return false with invalid confirm signature."
       )
+    })
+
+    it("Basic Pass & Fail - Two Inputs", async () => {
+      const validator = await ValidateWrapper.new()
+
+      const signer1 = accounts[1]
+      const signer2 = accounts[2]
+      const invalidSigner = accounts[3]
+
+      const txHash = web3.sha3("tx bytes to be hashed")
+      // Same transaction signed by both 1 and 2
+      const signature1 = await web3.eth.sign(signer1, txHash)
+      const signature2 = await web3.eth.sign(signer2, txHash)
+
+      const initialSigs = signature1 + signature2.slice(2)
+
+      const rootHash = web3.sha3("merkle root hash")
+      const confirmHash = keccak256(txHash, rootHash)
+
+      const confirmSignature1 = await web3.eth.sign(signer1, confirmHash)
+      const confirmSignature2 = await web3.eth.sign(signer2, confirmHash)
+
+      const confirmSigs = confirmSignature1 + confirmSignature2.slice(2)
+      const invalidConfirmSignature = await web3.eth.sign(invalidSigner, confirmHash)
+
+      // assert valid confirmSignatures will pass checkSigs
+      assert.isTrue(
+        await validator.checkSigs.call(txHash, rootHash, 1, initialSigs + confirmSigs.slice(2)),
+        "checkSigs doesn't return true when it should"
+      )
+
+      // assert invalid confirmSignatures will not pass checkSigs
+      assert.isFalse(
+        await validator.checkSigs.call(txHash, rootHash, 1, initialSigs + confirmSignature1.slice(2) + invalidConfirmSignature.slice(2)),
+        "checkSigs doesn't return false with invalid confirm signature."
+      )
+
     })
   })
 

--- a/test/validate.js
+++ b/test/validate.js
@@ -2,7 +2,6 @@ const ValidateWrapper = artifacts.require("ValidateWrapper")
 
 const {
   assertRejects,
-  keccak256,
   toHex
 } = require("./utilities.js")
 
@@ -14,7 +13,7 @@ contract("Validate", (accounts) => {
 
   const txHash = toHex(sha3("tx bytes to be hashed"))
   const rootHash = toHex(sha3("merkle root hash"))
-  const confirmHash = keccak256(txHash, rootHash)
+  const confirmHash = toHex(sha3(txHash + rootHash.slice(2)))
 
   const [signer1, signer2, invalidSigner] = accounts
 
@@ -162,17 +161,5 @@ contract("Validate", (accounts) => {
         "wrong order transaction signatures shouldn't pass"
       )
     })
-
-
-
-
-
-
-
-
-
-
-
   })
-
 })


### PR DESCRIPTION
These tests should cover all possible outcomes but still only getting 87.5% on the branch coverage. Not sure whats up but would like to get to the bottom of this. Wanted to avoid putting too many todos around the code, but I really think we should pass **inputCount** as a **Boolean** especially considering it is only able to hand the case for two inputs anyway. 

This will involve/require that we also change the uses of this function in the plasma contract. Not a huge refactoring, and could be done easily.